### PR TITLE
Support repos with more than 30 labels

### DIFF
--- a/lib/github-label-api.js
+++ b/lib/github-label-api.js
@@ -12,8 +12,13 @@ class ApiClient {
 
 	getLabels (repo) {
 		return new Promise((resolve, reject) => {
+			const allLabels = [];
 			const endpoint = `/repos/${repo}/labels`;
-			this.apiClient.get(endpoint, {}, (error, status, labels) => {
+			const params = {
+				page: 1,
+				per_page: 100
+			};
+			const getCallback = (error, status, labels) => {
 				if (error) {
 					error.method = 'GET';
 					error.endpoint = endpoint;
@@ -22,8 +27,15 @@ class ApiClient {
 				if (status !== 200) {
 					return reject(new Error(`API responded with ${status} status`));
 				}
-				resolve(labels);
-			});
+				allLabels.push.apply(allLabels, labels);
+				if (labels.length === params.per_page) {
+					params.page += 1;
+					this.apiClient.get(endpoint, params, getCallback);
+				} else {
+					resolve(allLabels);
+				}
+			};
+			this.apiClient.get(endpoint, params, getCallback);
 		});
 	}
 

--- a/test/unit/lib/github-label-api.js
+++ b/test/unit/lib/github-label-api.js
@@ -68,7 +68,7 @@ describe('lib/github-label-api', () => {
 
 				it('should make a GET request to the repo labels endpoint', () => {
 					assert.calledOnce(instance.apiClient.get);
-					assert.calledWith(instance.apiClient.get, `/repos/${repo}/labels`, {});
+					assert.calledWith(instance.apiClient.get, `/repos/${repo}/labels`, {page: 1, per_page: 100});
 				});
 
 				describe('.then()', () => {
@@ -82,7 +82,7 @@ describe('lib/github-label-api', () => {
 					});
 
 					it('should resolve with the repo labels', () => {
-						assert.strictEqual(resolvedValue, labels);
+						assert.deepEqual(resolvedValue, labels);
 					});
 
 				});


### PR DESCRIPTION
This changes the label-fetching code so it:

1) Requests 100 labels instead of the default 30
2) Continues requesting subsequent pages if it gets 100 labels back from the API

Fixes https://github.com/Financial-Times/github-label-sync/issues/4