### PR TITLE
Added ability to fetch descriptions for labels

### DIFF
--- a/lib/calculate-label-diff.js
+++ b/lib/calculate-label-diff.js
@@ -26,8 +26,14 @@ function calculateLabelDiff(currentLabels, configuredLabels) {
 		const matchedLabel = matches[0];
 		resolvedLabels.push(matchedLabel);
 
+		const matchedDescription = getLabelDescription(matchedLabel);
+		const configuredDescription = getLabelDescription(configuredLabel, matchedDescription);
+
 		// If we have a match, but properties are not equal
-		if (configuredLabel.name !== matchedLabel.name || configuredLabel.color !== matchedLabel.color) {
+		if (configuredLabel.name !== matchedLabel.name ||
+			configuredLabel.color !== matchedLabel.color ||
+			configuredDescription !== matchedDescription
+		) {
 			return diff.push(createChangedEntry(matchedLabel, configuredLabel));
 		}
 
@@ -38,8 +44,15 @@ function calculateLabelDiff(currentLabels, configuredLabels) {
 	return diff;
 }
 
+function getLabelDescription(label, fallback = '') {
+	if (label.description === undefined) {
+		return fallback;
+	}
+	return (label.description && label.description.trim()) || '';
+}
+
 function createMissingEntry(expectedLabel) {
-	return {
+	const missingEntry = {
 		name: expectedLabel.name,
 		type: 'missing',
 		actual: null,
@@ -48,10 +61,15 @@ function createMissingEntry(expectedLabel) {
 			color: expectedLabel.color
 		}
 	};
+	const expectedDescription = getLabelDescription(expectedLabel);
+	if (expectedDescription) {
+		missingEntry.expected.description = expectedDescription;
+	}
+	return missingEntry;
 }
 
 function createChangedEntry(actualLabel, expectedLabel) {
-	return {
+	const changedEntry = {
 		name: actualLabel.name,
 		type: 'changed',
 		actual: {
@@ -63,10 +81,20 @@ function createChangedEntry(actualLabel, expectedLabel) {
 			color: expectedLabel.color
 		}
 	};
+
+	const actualDescription = getLabelDescription(actualLabel);
+	const expectedDescription = getLabelDescription(expectedLabel, actualDescription);
+	if (actualDescription === expectedDescription && !actualDescription) {
+		return changedEntry;
+	}
+
+	changedEntry.actual.description = actualDescription;
+	changedEntry.expected.description = expectedDescription;
+	return changedEntry;
 }
 
 function createAddedEntry(actualLabel) {
-	return {
+	const addedEntry = {
 		name: actualLabel.name,
 		type: 'added',
 		actual: {
@@ -75,4 +103,9 @@ function createAddedEntry(actualLabel) {
 		},
 		expected: null
 	};
+	const actualDescription = getLabelDescription(actualLabel);
+	if (actualDescription) {
+		addedEntry.actual.description = actualDescription;
+	}
+	return addedEntry;
 }

--- a/lib/github-label-api.js
+++ b/lib/github-label-api.js
@@ -8,6 +8,7 @@ class ApiClient {
 
 	constructor (accessToken) {
 		this.apiClient = github.client(accessToken);
+		this.apiClient.requestDefaults.headers.Accept = 'application/vnd.github.symmetra-preview+json';
 	}
 
 	getLabels (repo) {

--- a/lib/stringify-label-diff.js
+++ b/lib/stringify-label-diff.js
@@ -8,7 +8,11 @@ function stringifyLabelDiff(labelDiff) {
 			return `Missing: the "${diffEntry.name}" label is missing from the repo. It will be created.`;
 		}
 		if (diffEntry.type === 'changed') {
-			return `Changed: the "${diffEntry.name}" label in the repo is out of date. It will be updated to "${diffEntry.expected.name}" with color "#${diffEntry.expected.color}".`;
+			const description = diffEntry.expected.description;
+
+			return `Changed: the "${diffEntry.name}" label in the repo is out of date.` +
+				` It will be updated to "${diffEntry.expected.name}" with color "#${diffEntry.expected.color}"` +
+				(description ? ` and description "${description}"` : '') + '.';
 		}
 		if (diffEntry.type === 'added') {
 			return `Added: the "${diffEntry.name}" label in the repo is not expected. It will be deleted.`;

--- a/test/unit/lib/action-label-diff.test.js
+++ b/test/unit/lib/action-label-diff.test.js
@@ -42,7 +42,8 @@ describe('lib/action-label-diff', () => {
 				actual: null,
 				expected: {
 					name: 'foo',
-					color: '00ff00'
+					color: '00ff00',
+					description: 'baz'
 				}
 			});
 			actions = actionLabelDiff(options);
@@ -60,11 +61,13 @@ describe('lib/action-label-diff', () => {
 				type: 'changed',
 				actual: {
 					name: 'foo',
-					color: 'ff0000'
+					color: 'ff0000',
+					description: 'bar'
 				},
 				expected: {
 					name: 'foo',
-					color: '00ff00'
+					color: '00ff00',
+					description: 'baz'
 				}
 			});
 			actions = actionLabelDiff(options);
@@ -82,7 +85,8 @@ describe('lib/action-label-diff', () => {
 				type: 'added',
 				actual: {
 					name: 'foo',
-					color: 'ff0000'
+					color: 'ff0000',
+					description: 'bar'
 				},
 				expected: null
 			});

--- a/test/unit/lib/calculate-label-diff.test.js
+++ b/test/unit/lib/calculate-label-diff.test.js
@@ -50,19 +50,51 @@ describe('lib/calculate-label-diff', () => {
 
 		});
 
+		describe('when a configured label with description does not exist in the current labels', () => {
+
+			beforeEach(() => {
+				currentLabels = [];
+				configuredLabels = [
+					{
+						name: 'bar',
+						color: '00ff00',
+						description: 'foo'
+					}
+				];
+				diff = calculateLabelDiff(currentLabels, configuredLabels);
+			});
+
+			it('should add a "missing" entry to the returned diff', () => {
+				assert.lengthEquals(diff, 1);
+				assert.deepEqual(diff[0], {
+					name: 'bar',
+					type: 'missing',
+					actual: null,
+					expected: {
+						name: 'bar',
+						color: '00ff00',
+						description: 'foo'
+					}
+				});
+			});
+
+		});
+
 		describe('when a configured label exists in the current labels with no changes', () => {
 
 			beforeEach(() => {
 				currentLabels = [
 					{
 						name: 'foo',
-						color: 'ff0000'
+						color: 'ff0000',
+						description: 'bar'
 					}
 				];
 				configuredLabels = [
 					{
 						name: 'foo',
-						color: 'ff0000'
+						color: 'ff0000',
+						description: 'bar'
 					}
 				];
 				diff = calculateLabelDiff(currentLabels, configuredLabels);
@@ -104,6 +136,110 @@ describe('lib/calculate-label-diff', () => {
 					expected: {
 						name: 'foo',
 						color: '00ff00'
+					}
+				});
+			});
+
+		});
+
+		describe('when a configured label with description exists in the current labels without description', () => {
+
+			beforeEach(() => {
+				currentLabels = [
+					{
+						name: 'foo',
+						color: 'ff0000'
+					}
+				];
+				configuredLabels = [
+					{
+						name: 'foo',
+						color: 'ff0000',
+						description: 'bar'
+					}
+				];
+				diff = calculateLabelDiff(currentLabels, configuredLabels);
+			});
+
+			it('should add a "changed" entry to the returned diff', () => {
+				assert.lengthEquals(diff, 1);
+				assert.deepEqual(diff[0], {
+					name: 'foo',
+					type: 'changed',
+					actual: {
+						name: 'foo',
+						color: 'ff0000',
+						description: ''
+					},
+					expected: {
+						name: 'foo',
+						color: 'ff0000',
+						description: 'bar'
+					}
+				});
+			});
+
+		});
+
+		describe('when a configured label without description exists in the current labels with description', () => {
+
+			beforeEach(() => {
+				currentLabels = [
+					{
+						name: 'foo',
+						color: 'ff0000',
+						description: 'bar'
+					}
+				];
+				configuredLabels = [
+					{
+						name: 'foo',
+						color: 'ff0000'
+					}
+				];
+				diff = calculateLabelDiff(currentLabels, configuredLabels);
+			});
+
+			it('should not add an entry to the returned diff', () => {
+				assert.lengthEquals(diff, 0);
+			});
+
+		});
+
+		describe('when a configured label with empty description exists in the current labels with description', () => {
+
+			beforeEach(() => {
+				currentLabels = [
+					{
+						name: 'foo',
+						color: 'ff0000',
+						description: 'bar'
+					}
+				];
+				configuredLabels = [
+					{
+						name: 'foo',
+						color: 'ff0000',
+						description: ''
+					}
+				];
+				diff = calculateLabelDiff(currentLabels, configuredLabels);
+			});
+
+			it('should add a "changed" entry to the returned diff', () => {
+				assert.lengthEquals(diff, 1);
+				assert.deepEqual(diff[0], {
+					name: 'foo',
+					type: 'changed',
+					actual: {
+						name: 'foo',
+						color: 'ff0000',
+						description: 'bar'
+					},
+					expected: {
+						name: 'foo',
+						color: 'ff0000',
+						description: ''
 					}
 				});
 			});
@@ -206,6 +342,36 @@ describe('lib/calculate-label-diff', () => {
 					actual: {
 						name: 'foo',
 						color: 'ff0000'
+					},
+					expected: null
+				});
+			});
+
+		});
+
+		describe('when a current label with description does not exist in the configured labels', () => {
+
+			beforeEach(() => {
+				currentLabels = [
+					{
+						name: 'foo',
+						color: 'ff0000',
+						description: 'bar'
+					}
+				];
+				configuredLabels = [];
+				diff = calculateLabelDiff(currentLabels, configuredLabels);
+			});
+
+			it('should add an "added" entry to the returned diff', () => {
+				assert.lengthEquals(diff, 1);
+				assert.deepEqual(diff[0], {
+					name: 'foo',
+					type: 'added',
+					actual: {
+						name: 'foo',
+						color: 'ff0000',
+						description: 'bar'
 					},
 					expected: null
 				});

--- a/test/unit/lib/github-label-api.test.js
+++ b/test/unit/lib/github-label-api.test.js
@@ -25,6 +25,11 @@ describe('lib/github-label-api', () => {
 			instance = githubLabelApi(accessToken);
 		});
 
+		it('should set the Accept header', () => {
+			assert.deepEqual(instance.apiClient.requestDefaults.headers.Accept,
+				'application/vnd.github.symmetra-preview+json');
+		});
+
 		it('should create an octonode API client with `accessToken`', () => {
 			assert.calledOnce(octonode.client);
 			assert.calledWithExactly(octonode.client.firstCall, accessToken);

--- a/test/unit/mock/octonode.js
+++ b/test/unit/mock/octonode.js
@@ -7,6 +7,9 @@ module.exports = {
 		del: sinon.stub(),
 		get: sinon.stub(),
 		patch: sinon.stub(),
-		post: sinon.stub()
+		post: sinon.stub(),
+		requestDefaults: {
+			headers: {}
+		},
 	})
 };


### PR DESCRIPTION
Label descriptions are still a preview feature but we can get its
functionality if we pass a header of specific value down to octonode.

~While this doesn't address setting the description, it should make it easier to do
so for those who continue this work.~

@sjawhar has added work for setting the descriptions too 👍 

Issue:
https://github.com/Financial-Times/github-label-sync/issues/16

Header:
```
Accept: application/vnd.github.symmetra-preview+json
```

Blogpost:
https://developer.github.com/changes/2018-02-22-label-description-search-preview/