### PR TITLE
add support for GitHub enterprise

### DIFF
--- a/bin/github-label-sync.js
+++ b/bin/github-label-sync.js
@@ -29,6 +29,11 @@ program
 		'-A, --allow-added-labels',
 		'allow additional labels in the repo, and don\'t delete them'
 	)
+	.option(
+		'-e, --endpoint <url>',
+		'specify a GitHub enterprise installation',
+		undefined
+	)
 	.parse(process.argv);
 
 // Make sure we have exactly one argument – the repo
@@ -81,6 +86,7 @@ function resolveOptions() {
 			accessToken: program.accessToken,
 			allowAddedLabels: program.allowAddedLabels,
 			dryRun: program.dryRun,
+			endpoint: program.endpoint,
 			format: format,
 			labels: labels,
 			log: console,

--- a/lib/github-label-api.js
+++ b/lib/github-label-api.js
@@ -6,8 +6,9 @@ module.exports = createApiClient;
 
 class ApiClient {
 
-	constructor (accessToken) {
-		this.apiClient = github.client(accessToken);
+	constructor (accessToken, apiEndpoint) {
+		const urlOptions = apiEndpoint === undefined ? {} : { hostname: apiEndpoint };
+		this.apiClient = github.client(accessToken, urlOptions);
 	}
 
 	getLabels (repo) {
@@ -94,6 +95,6 @@ class ApiClient {
 
 }
 
-function createApiClient(accessToken) {
-	return new ApiClient(accessToken);
+function createApiClient(accessToken, apiEndpoint) {
+	return new ApiClient(accessToken, apiEndpoint);
 }

--- a/lib/github-label-sync.js
+++ b/lib/github-label-sync.js
@@ -12,6 +12,7 @@ module.exports.defaults = {
 	accessToken: null,
 	allowAddedLabels: false,
 	dryRun: false,
+	endpoint: null,
 	format: {
 		diff: echo,
 		success: echo,
@@ -28,7 +29,7 @@ module.exports.defaults = {
 function githubLabelSync(options) {
 	options = extend(true, {}, module.exports.defaults, options);
 
-	const apiClient = githubLabelApi(options.accessToken);
+	const apiClient = githubLabelApi(options.accessToken, options.endpoint);
 	const format = options.format;
 	const log = options.log;
 	let labelDiff;

--- a/test/unit/lib/github-label-api.test.js
+++ b/test/unit/lib/github-label-api.test.js
@@ -25,9 +25,9 @@ describe('lib/github-label-api', () => {
 			instance = githubLabelApi(accessToken);
 		});
 
-		it('should create an octonode API client with `accessToken`', () => {
+		it('should create an API client with `accessToken` and no overridden endpoint', () => {
 			assert.calledOnce(octonode.client);
-			assert.calledWithExactly(octonode.client.firstCall, accessToken);
+			assert.calledWithExactly(octonode.client.firstCall, accessToken, {});
 		});
 
 		it('should return an object', () => {
@@ -441,6 +441,21 @@ describe('lib/github-label-api', () => {
 
 				});
 
+			});
+
+		});
+
+	});
+
+	describe('githubLabelApi(accessToken, apiEndpoint)', () => {
+		it('should create an API client with `accessToken` and `apiEndpoint` as hostname', () => {
+			const accessToken = 'mock-github-access-token';
+			const endpoint = 'github.example.com';
+
+			githubLabelApi(accessToken, endpoint);
+			assert.calledOnce(octonode.client);
+			assert.calledWithExactly(octonode.client.firstCall, accessToken, {
+				hostname: endpoint
 			});
 
 		});

--- a/test/unit/lib/github-label-sync.test.js
+++ b/test/unit/lib/github-label-sync.test.js
@@ -179,7 +179,7 @@ describe('lib/github-label-sync', () => {
 
 		it('should create a githubLabelApi client with `options.accessToken`', () => {
 			assert.calledOnce(githubLabelApi);
-			assert.calledWithExactly(githubLabelApi.firstCall, options.accessToken);
+			assert.calledWithExactly(githubLabelApi.firstCall, options.accessToken, null);
 		});
 
 		it('should return a promise', function() {


### PR DESCRIPTION
Extended the application to take an additional argument `-e` which specifies the GitHub endpoint:

```
bin/github-label-sync.js -e github.example.com/api/v3 repo/name
```

extended tests for github-label-api, not so much for github-label-sync - the setup is a bit dense