### PR TITLE
lowercase alias name to ensure it can match the label if the label was mixed-case

### DIFF
--- a/lib/calculate-label-diff.js
+++ b/lib/calculate-label-diff.js
@@ -12,7 +12,7 @@ function calculateLabelDiff(currentLabels, configuredLabels) {
 			if (currentLabel.name.toLowerCase() === configuredLabel.name.toLowerCase()) {
 				return true;
 			}
-			if (configuredLabel.aliases && configuredLabel.aliases.indexOf(currentLabel.name.toLowerCase()) !== -1) {
+			if (configuredLabel.aliases && configuredLabel.aliases.map(label => label.toLowerCase()).indexOf(currentLabel.name.toLowerCase()) !== -1) {
 				return true;
 			}
 		});


### PR DESCRIPTION
Resolves https://github.com/Financial-Times/github-label-sync/issues/26