### PR TITLE
Document 'description' field in label json

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ The labels to sync with are defined as an array in either JavaScript or JSON. Th
 {
 	"name": "mylabel",
 	"color": "ff0000",
-	"aliases": []
+	"aliases": [],
+	"description": "optional description"
 }
 ```
 


### PR DESCRIPTION
The 'description' field can be specified as part of the label JSON, but this doesn't seem to be documented.

Add it to the example label JSON, so that users understand they can optionally include it.