### PR TITLE
feat: add-yaml-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Run GitHub Label Sync using a different [label config file](#label-json):
 github-label-sync --access-token xxxxxx --labels my-labels.json myname/myrepo
 ```
 
+[Label config file](#label-json) can be also specified as YAML:
+
+```sh
+github-label-sync --access-token xxxxxx --labels my-labels.yml myname/myrepo
+```
+
 Perform a dry run, only making safe "read" requests to the GitHub API:
 
 ```sh
@@ -153,7 +159,9 @@ When the promise resolves successfully, its value will be set to a diff between 
 Label JSON
 ----------
 
-The labels to sync with are defined as an array in either JavaScript or JSON. The array must contain only label objects, which look like this:
+The labels to sync with are defined as an array in either JavaScript, JSON or YAML. The array must contain only label objects, which look like this:
+
+As JSON:
 
 ```json
 {
@@ -162,6 +170,15 @@ The labels to sync with are defined as an array in either JavaScript or JSON. Th
 	"aliases": [],
 	"description": "optional description"
 }
+```
+
+As YAML:
+
+```yaml
+- name: mylabel
+  color: "ff0000"
+  aliases: []
+  description: optional description
 ```
 
 The `name` property refers to the label name and the `color` property should be set to the color of the label as a hex code without the leading `#`.
@@ -181,7 +198,7 @@ For example, given the following config, GitHub Label Sync will look for labels 
 }
 ```
 
-You can find a [full example label configuration](labels.json) in this repository.
+You can find a full example label configuration in this repository ([JSON](labels.json) / [YAML](labels.yml)).
 
 
 Configuration
@@ -246,7 +263,7 @@ githubLabelSync({
 });
 ```
 
-On the command-line this can be set with the `labels` flag which should point to a JSON file.
+On the command-line this can be set with the `labels` flag which should point to a JSON or YAML file.
 
 ### `repo`
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Table Of Contents
 - [Requirements](#requirements)
 - [Command-Line Interface](#command-line-interface)
 - [JavaScript Interface](#javascript-interface)
-- [Label JSON](#label-json)
+- [Label Config File](#label-config-file)
 - [Configuration](#configuration)
 - [Contributing](#contributing)
 - [License](#license)
@@ -45,19 +45,19 @@ Options:
   -A, --allow-added-labels    allow additional labels in the repo, and don't delete them
 ```
 
-Run GitHub Label Sync on a repo (reading [label data](#label-json) from a local `labels.json`):
+Run GitHub Label Sync on a repo (reading [label data](#label-config-file) from a local `labels.json`):
 
 ```sh
 github-label-sync --access-token xxxxxx myname/myrepo
 ```
 
-Run GitHub Label Sync using a different [label config file](#label-json):
+Run GitHub Label Sync using a different [label config file](#label-config-file):
 
 ```sh
 github-label-sync --access-token xxxxxx --labels my-labels.json myname/myrepo
 ```
 
-[Label config file](#label-json) can be also specified as YAML:
+[Label config file](#label-config-file) can be also specified as YAML:
 
 ```sh
 github-label-sync --access-token xxxxxx --labels my-labels.yml myname/myrepo
@@ -156,7 +156,7 @@ When the promise resolves successfully, its value will be set to a diff between 
 ```
 
 
-Label JSON
+Label Config File
 ----------
 
 The labels to sync with are defined as an array in either JavaScript, JSON or YAML. The array must contain only label objects, which look like this:
@@ -223,7 +223,7 @@ GITHUB_ACCESS_TOKEN=xxxxxx github-label-sync
 
 ### `allowAddedLabels`
 
-_Boolean_. Whether to allow labels on GitHub which are not specified in your [label config](#label-json). If `true`, they are allowed and will be left alone. If `false`, they will be deleted. Default: `false`.
+_Boolean_. Whether to allow labels on GitHub which are not specified in your [label config](#label-config-file). If `true`, they are allowed and will be left alone. If `false`, they will be deleted. Default: `false`.
 
 ```js
 githubLabelSync({
@@ -255,7 +255,7 @@ github-label-sync --dry-run
 
 ### `labels`
 
-_Array_. Your label configuration. See the section on [label JSON](#label-json).
+_Array_. Your label configuration. See the section on [label config file](#label-config-file).
 
 ```js
 githubLabelSync({

--- a/labels.yml
+++ b/labels.yml
@@ -1,0 +1,69 @@
+- name: "type: bug"
+  color: "e11d21"
+  aliases:
+    - bug
+- name: "type: breaking"
+  color: "990000"
+  aliases:
+    - breaking
+    - "breaking-change"
+- name: "type: maintenance"
+  color: "fbca04"
+  aliases:
+    - maintenance
+    - refactor
+    - testing
+    - test
+- name: "type: enhancement"
+  color: "009800"
+  aliases:
+    - enhancement
+    - feature
+- name: "type: question"
+  color: "cc317c"
+  aliases:
+    - question
+- name: "type: discussion"
+  color: "cc317c"
+  aliases:
+    - discussion
+- name: "type: documentation"
+  color: 207de5
+  aliases:
+    - documentation
+- name: "type: design"
+  color: eb6420
+  aliases:
+    - design
+- name: "priority: low"
+  color: 009800
+- name: "priority: medium"
+  color: fbca04
+- name: "priority: high"
+  color: eb6420
+- name: "priority: critical"
+  color: e11d21
+- name: "status: good starter issue"
+  color: bfe5bf
+  aliases:
+    - "beginner-friendly"
+    - beginner
+    - "good-starter-issue"
+    - "starter-issue"
+- name: "status: help wanted"
+  color: bfe5bf
+  aliases:
+    - "help wanted"
+- name: "status: wontfix"
+  color: cccccc
+  aliases:
+    - wontfix
+    - "wont-fix"
+- name: "status: duplicate"
+  color: cccccc
+  aliases:
+    - duplicate
+- name: "status: blocked"
+  color: "990000"
+  aliases:
+    - blocked

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -590,8 +589,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "esquery": {
       "version": "1.0.1",
@@ -1156,7 +1154,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1787,8 +1784,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.15.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "chalk": "^1",
     "commander": "^2",
     "got": "^7.1.0",
+    "js-yaml": "^3.13.1",
     "node.extend": "^2.0.2",
     "octonode": "^0.9.5"
   },


### PR DESCRIPTION
Hi, based on #24, I adeed yaml support.

### Description
Yaml support.

### Details
If the file or url of the labels file ends with .yaml or .yml, the file is parsed as yaml.

I also added an example labels.yml file in case you would want to include a .yml version somewhere in the repo too, as an example.

Lint and tests passed.

I haven't added new tests, though. Wasn't clear where the tests for parsing the file should be added. Guidance on this is welcome.

I haven't changed the documentation. Clarification on that would help too.

Could you have a look at the PR and provide guidance on next steps if the feature would be relevant for this package?

### Relevant Issues
#24