### PR TITLE
Fix downloading YAML from URLs

### DIFF
--- a/bin/github-label-sync.js
+++ b/bin/github-label-sync.js
@@ -61,7 +61,11 @@ function readLabels() {
 		if (file.indexOf('http://') === 0 || file.indexOf('https://') === 0) {
 			const got = require('got');
 
-			const options = { json: !isYaml };
+			const options = {};
+			if (!isYaml) {
+				options.json = true;
+			}
+
 			files.push(got(file, options)
 				.then((response) => {
 					return isYaml ? yaml.safeLoad(response.body): response.body;


### PR DESCRIPTION
When downloading YAML from a URL, the `options.json` value is set to `false` which is treated as an empty body (however, the body is still set). This causes an error when downloading a YAML set [such as mine](https://raw.githubusercontent.com/owenvoke/github-label-presets/master/labels.yml).

![Preview image of the error](https://user-images.githubusercontent.com/1899334/85998294-84447000-ba02-11ea-806b-1a0ddfcb8365.png)
