### PR TITLE
Add typings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 coverage
+typings

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "main": "lib/github-label-sync.js",
   "bin": "bin/github-label-sync.js",
+  "types": "typings/github-label-sync.d.ts",
   "dependencies": {
     "@financial-times/origami-service-makefile": "^7.0.3",
     "chalk": "^4",

--- a/typings/github-label-sync.d.ts
+++ b/typings/github-label-sync.d.ts
@@ -19,6 +19,12 @@ export interface Options {
   repo: string
 }
 
+export interface DefaultOptions extends Options {
+  accessToken: null
+  endpoint: null
+  repo: null
+}
+
 export interface LabelDiff {
   name: string
   type: string
@@ -26,6 +32,6 @@ export interface LabelDiff {
   expected?: BasicLabel
 }
 
-export const deafults: Required<Options>
+export const defaults: Required<DefaultOptions>
 
 export default function githubLabelSync(options: Options): Promise<LabelDiff[]>

--- a/typings/github-label-sync.d.ts
+++ b/typings/github-label-sync.d.ts
@@ -1,0 +1,31 @@
+export interface BasicLabel {
+  name: string
+  color: string
+}
+
+export interface LabelInfo extends BasicLabel {
+  aliases?: string[]
+  description?: string
+}
+
+export interface Options {
+  accessToken: string
+  allowAddedLabels?: boolean
+  dryRun?: boolean
+  endpoint?: string
+  format?: Partial<Record<'diff' | 'success' | 'warning', (str: string) => string>>
+  labels: LabelInfo[]
+  log?: Partial<Record<'info' | 'warn', (str: string) => void>>
+  repo: string
+}
+
+export interface LabelDiff {
+  name: string
+  type: string
+  actual?: BasicLabel
+  expected?: BasicLabel
+}
+
+export const deafults: Required<Options>
+
+export default function githubLabelSync(options: Options): Promise<LabelDiff[]>


### PR DESCRIPTION
This PR adds typings to the package.
- For JS users: your IDE can now see these and can provide additional documentation
- For TS users: you can now use this package with static type-checking

These typings need to be updated if there's any change to the options type or the type of the array to which the promise resolves.