### PR TITLE
Set origamiType to cli

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -1,6 +1,6 @@
 {
 	"description": "Synchronise your GitHub labels with as few destructive operations as possible",
-	"origamiType": null,
+	"origamiType": "cli",
 	"origamiVersion": 1,
 	"keywords": [],
 	"support": "https://github.com/Financial-Times/github-label-sync/issues",


### PR DESCRIPTION
this one is a library _and_ a command line tool, but i think we should mark anything with a command line interface as "cli"