### PR TITLE
Allow directly calling ./bin/github-label-sync.js

### DIFF
--- a/bin/github-label-sync.js
+++ b/bin/github-label-sync.js
@@ -11,7 +11,7 @@ const yaml = require('js-yaml');
 
 // Command-line configuration
 program
-	.version(pkg.version)
+	.version(pkg.version || 'unknown')
 	.usage('[options] <repository>')
 	.option(
 		'-a, --access-token <token>',


### PR DESCRIPTION
The `pkg.version` property is not defined when running from a clone of
this repo. That causes the script to fail when invoked:

    $ ./bin/github-label-sync.js -d -l labels.json Financial-Times/github-label-sync
    /tmp/github-label-sync/bin/github-label-sync.js:15
    	.usage('[options] <repository>')
    	^

    TypeError: Cannot read property 'usage' of undefined
        at Object.<anonymous> (/tmp/github-label-sync/bin/github-label-sync.js:15:2)
        at Module._compile (node:internal/modules/cjs/loader:1092:14)
        at Object.Module._extensions..js (node:internal/modules/cjs/loader:1121:10)
        at Module.load (node:internal/modules/cjs/loader:972:32)
        at Function.Module._load (node:internal/modules/cjs/loader:813:14)
        at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)
        at node:internal/main/run_main_module:17:47

Providing a fallback value allows everything to work as expected.