### PR TITLE
Record all current label matches as resolved

### DIFF
--- a/lib/calculate-label-diff.js
+++ b/lib/calculate-label-diff.js
@@ -24,7 +24,7 @@ function calculateLabelDiff(currentLabels, configuredLabels) {
 
 		// Always take the first match
 		const matchedLabel = matches[0];
-		resolvedLabels.push(matchedLabel);
+		resolvedLabels.push(...matches);
 
 		const matchedDescription = getLabelDescription(matchedLabel);
 		const configuredDescription = getLabelDescription(configuredLabel, matchedDescription);

--- a/test/unit/lib/calculate-label-diff.test.js
+++ b/test/unit/lib/calculate-label-diff.test.js
@@ -321,6 +321,93 @@ describe('lib/calculate-label-diff', () => {
 
 		});
 
+		describe('when a configured label alias exists in the current labels, and the configured label exists in the current labels', () => {
+
+			beforeEach(() => {
+				currentLabels = [
+					{
+						name: 'bar',
+						color: '00ff00'
+					},
+					{
+						name: 'foo',
+						color: 'ff0000'
+					}
+				];
+				configuredLabels = [
+					{
+						name: 'foo',
+						color: '0000ff',
+						aliases: [
+							'bar'
+						]
+					}
+				];
+				diff = calculateLabelDiff(currentLabels, configuredLabels);
+			});
+
+			it('should only add a "changed" entry for the first match to the returned diff', () => {
+				assert.lengthEquals(diff, 1);
+				assert.deepEqual(diff[0], {
+					name: 'bar',
+					type: 'changed',
+					actual: {
+						name: 'bar',
+						color: '00ff00'
+					},
+					expected: {
+						name: 'foo',
+						color: '0000ff'
+					}
+				});
+			});
+
+		});
+
+		describe('when multiple aliases of a configured label exist in the current labels', () => {
+
+			beforeEach(() => {
+				currentLabels = [
+					{
+						name: 'bar',
+						color: '00ff00'
+					},
+					{
+						name: 'foo',
+						color: 'ff0000'
+					}
+				];
+				configuredLabels = [
+					{
+						name: 'baz',
+						color: '0000ff',
+						aliases: [
+							'foo',
+							'bar'
+						]
+					}
+				];
+				diff = calculateLabelDiff(currentLabels, configuredLabels);
+			});
+
+			it('should only add a "changed" entry for the first match to the returned diff', () => {
+				assert.lengthEquals(diff, 1);
+				assert.deepEqual(diff[0], {
+					name: 'bar',
+					type: 'changed',
+					actual: {
+						name: 'bar',
+						color: '00ff00'
+					},
+					expected: {
+						name: 'baz',
+						color: '0000ff'
+					}
+				});
+			});
+
+		});
+
 		describe('when a current label does not exist in the configured labels', () => {
 
 			beforeEach(() => {


### PR DESCRIPTION
There are two scenarios where multiple current labels can match a configured label:

- The configured label exists in the current labels and an alias exists in the current labels
- Multiple aliases of the configured label exist in the current labels

As a partial workaround for the lack of a label merge capability in GitHub Label Sync (https://github.com/Financial-Times/github-label-sync/issues/12), only the first matching label is processed for the creation of a diff entry. 

This approach was mistakenly applied also in adding matches to the list of "resolved" labels. That caused the tool to think that any additional matching labels did not match any label configuration, which resulted in "added" entries being created for them, and **🐛 their incorrect deletion 🐛** in the default mode where additional labels are not allowed.

## To reproduce

1. Add the following labels to a repository:
   - **`type: feature`**
   - **`enhancement`**
1. Apply the labels to some issues or PRs.
1. Create the following **`labels.json`**:
   ```json
   [
     {
       "name": "type: feature",
       "color": "00ff00",
       "aliases": ["enhancement"]
     }
   ]
   ```
1. Run `github-label-sync` on the repository with the configuration you created.

## Previous behavior

```text
$ github-label-sync per1234/some-repo
Syncing labels for "per1234/some-repo"
Validating provided labels
Fetching labels from GitHub
 > Changed: the "enhancement" label in the repo is out of date. It will be updated to "type: feature" with color "#00ff00".
 > Added: the "type: feature" label in the repo is not expected. It will be deleted.
Applying label changes, please wait…
GitHub Error:
PATCH /repos/per1234/some-repo/labels/enhancement
422: Validation Failed
```

:bug: The "**`type: feature`**" label is incorrectly deleted. The label has been removed from all issues and PRs.

## Behavior after the changes from this PR

```text
$ github-label-sync per1234/some-repo
Syncing labels for "per1234/some-repo"
Validating provided labels
Fetching labels from GitHub
 > Changed: the "enhancement" label in the repo is out of date. It will be updated to "type: feature" with color "#00ff00".
Applying label changes, please wait…
GitHub Error:
PATCH /repos/per1234/some-repo/labels/enhancement
422: Validation Failed
```

🙂 The "**`type: feature`**" label is not deleted.

🙁 The attempt to change the "**`enhancement`**" label to "**`type: feature`**" still fails (https://github.com/Financial-Times/github-label-sync/issues/149), but that is the same behavior as always, caused by the lack of a merge capability. I will submit a separate PR to improve the tool's handling of configurations that require a merge operation, but that proposal is out of scope for this PR, which is intended only to address the critical bug that results in unwanted label deletion.