### PR TITLE
Delete labels feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ As JSON:
 	"name": "mylabel",
 	"color": "ff0000",
 	"aliases": [],
-	"description": "optional description"
+	"description": "optional description",
+	"delete": false
 }
 ```
 
@@ -179,10 +180,12 @@ As YAML:
   color: "ff0000"
   aliases: []
   description: optional description
+  delete: false
 ```
 
 - The `name` property refers to the label name.
 - The `color` property should be a hex code, with or without the leading `#`.
+- The `delete` property is optional. When set to true, matches for this label will _always_ be deleted. This can be used in conjunction with [allowAddedLabels](#allowaddedlabels) to flag specific labels for deletion while leaving non-specified labels intact.
 
 The `aliases` property is optional. When GitHub Label Sync is determining whether to update or delete/create a label it will use the aliases property to prevent used labels from being deleted.
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ As YAML:
 
 - The `name` property refers to the label name.
 - The `color` property should be a hex code, with or without the leading `#`.
-- The `delete` property is optional. When set to true, matches for this label will _always_ be deleted. This can be used in conjunction with [allowAddedLabels](#allowaddedlabels) to flag specific labels for deletion while leaving non-specified labels intact.
+- The `delete` property is optional. When set to `true`, matches for this label will _always_ be deleted. This can be used in conjunction with [allowAddedLabels](#allowaddedlabels) to flag specific labels for deletion while leaving non-specified labels intact. Defaults to `false`.
 
 The `aliases` property is optional. When GitHub Label Sync is determining whether to update or delete/create a label it will use the aliases property to prevent used labels from being deleted.
 

--- a/lib/calculate-label-diff.js
+++ b/lib/calculate-label-diff.js
@@ -2,7 +2,7 @@
 
 module.exports = calculateLabelDiff;
 
-function calculateLabelDiff(currentLabels, configuredLabels) {
+function calculateLabelDiff(currentLabels, configuredLabels, allowAddedLabels) {
 	const diff = [];
 	const resolvedLabels = [];
 	configuredLabels.forEach((configuredLabel) => {
@@ -25,11 +25,14 @@ function calculateLabelDiff(currentLabels, configuredLabels) {
 		resolvedLabels.push(...matches);
 
 		// If we have no matches, the configured label is missing
-		if (matches.length === 0) {
+		// Do not create label if set to delete
+		if (matches.length === 0 && !configuredLabel.delete) {
 			return diff.push(createMissingEntry(configuredLabel));
 		}
 
 		matches.forEach((matchedLabel, index) => {
+
+			if (configuredLabel.delete) return diff.push(createAddedEntry(matchedLabel));
 
 			const matchedDescription = getLabelDescription(matchedLabel);
 			const configuredDescription = getLabelDescription(configuredLabel, matchedDescription);
@@ -52,7 +55,7 @@ function calculateLabelDiff(currentLabels, configuredLabels) {
 
 	});
 	currentLabels.filter(label => resolvedLabels.indexOf(label) === -1).forEach((currentLabel) => {
-		diff.push(createAddedEntry(currentLabel));
+		if(!allowAddedLabels) diff.push(createAddedEntry(currentLabel));
 	});
 	return diff;
 }

--- a/lib/calculate-label-diff.js
+++ b/lib/calculate-label-diff.js
@@ -32,7 +32,9 @@ function calculateLabelDiff(currentLabels, configuredLabels, allowAddedLabels) {
 
 		matches.forEach((matchedLabel, index) => {
 
-			if (configuredLabel.delete) return diff.push(createAddedEntry(matchedLabel));
+			if (configuredLabel.delete) {
+				return diff.push(createAddedEntry(matchedLabel));
+			}
 
 			const matchedDescription = getLabelDescription(matchedLabel);
 			const configuredDescription = getLabelDescription(configuredLabel, matchedDescription);
@@ -55,7 +57,9 @@ function calculateLabelDiff(currentLabels, configuredLabels, allowAddedLabels) {
 
 	});
 	currentLabels.filter(label => resolvedLabels.indexOf(label) === -1).forEach((currentLabel) => {
-		if(!allowAddedLabels) diff.push(createAddedEntry(currentLabel));
+		if (!allowAddedLabels) {
+			diff.push(createAddedEntry(currentLabel));
+		}
 	});
 	return diff;
 }

--- a/lib/github-label-sync.js
+++ b/lib/github-label-sync.js
@@ -65,12 +65,7 @@ function githubLabelSync(options) {
 
 	return apiClient.getLabels(options.repo)
 		.then((currentLabels) => {
-			labelDiff = calculateLabelDiff(currentLabels, options.labels).filter((diff) => {
-				if (options.allowAddedLabels && diff.type === 'added') {
-					return false;
-				}
-				return true;
-			});
+			labelDiff = calculateLabelDiff(currentLabels, options.labels, options.allowAddedLabels);
 			stringifyLabelDiff(labelDiff).forEach((diffLine) => {
 				log.info(format.diff(diffLine));
 			});

--- a/lib/validate-label-format.js
+++ b/lib/validate-label-format.js
@@ -10,6 +10,7 @@ const schema = {
 		name: { type: 'string', maxLength: 50, },
 		color: { type: 'string', pattern: '^[a-fA-F0-9]{6}$' },
 		description: { type: 'string', maxLength: 100 },
+		delete: { type: 'boolean' },
 		aliases: {
 			type: 'array',
 			items: { type: 'string', maxLength: 50 }

--- a/lib/validate-label-format.js
+++ b/lib/validate-label-format.js
@@ -10,7 +10,7 @@ const schema = {
 		name: { type: 'string', maxLength: 50, },
 		color: { type: 'string', pattern: '^[a-fA-F0-9]{6}$' },
 		description: { type: 'string', maxLength: 100 },
-		delete: { type: 'boolean' },
+		delete: { type: 'boolean', default: false },
 		aliases: {
 			type: 'array',
 			items: { type: 'string', maxLength: 50 }

--- a/test/unit/lib/calculate-label-diff.test.js
+++ b/test/unit/lib/calculate-label-diff.test.js
@@ -168,25 +168,39 @@ describe('lib/calculate-label-diff', () => {
 					{
 						name: 'foo',
 						color: 'ff0000',
+					},
+					{
+						name: 'bar',
+						color: '00ff00',
 					}
 				];
 				configuredLabels = [
 					{
 						name: 'foo',
-						delete: true
+						delete: true,
+						aliases: ['bar']
 					}
 				];
 				diff = calculateLabelDiff(currentLabels, configuredLabels);
 			});
 
-			it('should add an "added" entry to the returned diff', () => {
-				assert.lengthEquals(diff, 1);
+			it('should add an "added" entry to the returned diff for each match', () => {
+				assert.lengthEquals(diff, 2);
 				assert.deepEqual(diff[0], {
 					name: 'foo',
 					type: 'added',
 					actual: {
 						name: 'foo',
 						color: 'ff0000',
+					},
+					expected: null
+				});
+				assert.deepEqual(diff[1], {
+					name: 'bar',
+					type: 'added',
+					actual: {
+						name: 'bar',
+						color: '00ff00',
 					},
 					expected: null
 				});

--- a/test/unit/lib/github-label-sync.test.js
+++ b/test/unit/lib/github-label-sync.test.js
@@ -203,7 +203,7 @@ describe('lib/github-label-sync', () => {
 
 			it('should diff the labels returned from the API against `options.labels`', () => {
 				assert.calledOnce(calculateLabelDiff);
-				assert.calledWithExactly(calculateLabelDiff, labelsFromApi, options.labels);
+				assert.calledWithExactly(calculateLabelDiff, labelsFromApi, options.labels, false);
 			});
 
 			it('should stringify and log the returned diff', () => {
@@ -294,18 +294,8 @@ describe('lib/github-label-sync', () => {
 		describe('when the `allowAddedLabels` option is `true`', () => {
 
 			beforeEach(() => {
-				labelDiff.push({
-					name: 'bar',
-					type: 'added',
-					actual: {
-						name: 'bar',
-						color: '00ff00'
-					},
-					expected: null
-				});
 				options.allowAddedLabels = true;
-				actionLabelDiff.reset();
-				stringifyLabelDiff.reset();
+				calculateLabelDiff.reset();
 				returnedPromise = githubLabelSync(options);
 			});
 
@@ -316,16 +306,10 @@ describe('lib/github-label-sync', () => {
 						done();
 					}).catch(done);
 				});
-
-				it('should not include "added" diffs in stringification', () => {
-					assert.calledOnce(stringifyLabelDiff);
-					assert.deepEqual(stringifyLabelDiff.firstCall.args[0], [labelDiff[0]]);
-				});
-
-				it('should not convert "added" diffs to promises', () => {
-					assert.calledOnce(actionLabelDiff);
-					assert.isObject(actionLabelDiff.firstCall.args[0]);
-					assert.deepEqual(actionLabelDiff.firstCall.args[0].diff, [labelDiff[0]]);
+			
+				it('should call calculateLabelDiff with the `allowAddedLabels` flag set to true', () => {
+					assert.calledOnce(calculateLabelDiff);
+					assert.calledWithExactly(calculateLabelDiff, labelsFromApi, options.labels, true);
 				});
 
 			});


### PR DESCRIPTION
Resolves #182 

This PR introduces an optional `delete` flag for labels. When `true`, matching labels will _always_ be deleted. This can be used in conjunction with the `allowAddedLabels` flag to mark a subset of labels for deletion while leaving others intact, allowing more fine-grained control over label management.

Labels in the local configuration that are missing in the remote will not be created if they are flagged for deletion in the config.

In order to facilitate overriding `allowAddedLabels`, logic for `allowAddedLabels` has been moved down into `calculateLabelDiff` - I considered some alternatives but this felt like the cleanest way to do it, though additional feedback and suggestions are very welcome! Tests and readme have been updated accordingly.